### PR TITLE
nginx: added robots.txt rule

### DIFF
--- a/demo-inveniordm/docker/nginx/conf.d/default.conf
+++ b/demo-inveniordm/docker/nginx/conf.d/default.conf
@@ -122,4 +122,9 @@ server {
     alias /opt/invenio/var/instance/static;
     autoindex off;
   }
+  # Robots.txt file is served by nginx.
+  location /robots.txt {
+    alias /opt/invenio/var/instance/static/robots.txt;
+    autoindex off;
+  }
 }


### PR DESCRIPTION
closes https://github.com/inveniosoftware/helm-invenio/issues/47

Notes:

- file `robots.txt` was [added](https://github.com/inveniosoftware/invenio-app-rdm/commit/cb5bd39104c8a40ef98a18b3b7c42d7da877e08d) in `invenio-app-rdm` and won't be available for this image until the version of `invenio-app-rdm` is upgraded.