### PR TITLE
ci: improve docker publish

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -17,38 +17,43 @@ on:
         default: "Manual trigger"
 
 env:
+  REGISTRY: ghcr.io
   IMAGE_NAME: demo-inveniordm
 
 jobs:
   push:
 
+    name: Publish images
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - name: Build image
-        run: |
-          docker build ./demo-inveniordm/ --tag image --build-arg include_assets=true
+      - name: Extract GIT metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=true
 
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKER_PUBLISH_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag image $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - name: Build and publish image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./demo-inveniordm/
+          file: ./demo-inveniordm/Dockerfile
+          build-args: |
+            include_assets=true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Uses actions instead of custom code to extract git refs.
- Removes needs of the extra secret `DOCKER_PUBLISH_TOKEN`, which can be deleted.