### PR TITLE
global: add app_data to docker image

### DIFF
--- a/demo-inveniordm/Dockerfile
+++ b/demo-inveniordm/Dockerfile
@@ -28,6 +28,7 @@ RUN pipenv install --deploy --system
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
 COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
+COPY ./app_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 COPY ./ .
 
 RUN if [ "$include_assets" = "true" ]; \


### PR DESCRIPTION
- closes #115 

Since `app_data` was not copied none of the custom vocabularies was created, then failing on aggregations (silent/hidden) failure.